### PR TITLE
Fix a typo

### DIFF
--- a/include/umappp/Umap.hpp
+++ b/include/umappp/Umap.hpp
@@ -164,7 +164,7 @@ public:
         /**
          * See `set_num_threads()`.
          */
-        static constexpr bool num_threads = 1;
+        static constexpr int num_threads = 1;
     };
 
 private:


### PR DESCRIPTION
I just found out that this great library has been updated. So I was updating the Umappp binding in Ruby and noticed that num_thread is `ture` by default. While investigating the cause of this, I realized that the declaration of this variable is actually a `bool`. I thought this was most likely an `int`. So I created a pull request. If I am wrong, feel free to close it. Best regards.