### PR TITLE
Inline choose_num_epochs to fix multiple definition error

### DIFF
--- a/include/umappp/Umap.hpp
+++ b/include/umappp/Umap.hpp
@@ -38,7 +38,7 @@ enum InitMethod { SPECTRAL, SPECTRAL_ONLY, RANDOM, NONE };
 /**
  * @cond
  */
-int choose_num_epochs(int num_epochs, size_t size) {
+inline int choose_num_epochs(int num_epochs, size_t size) {
     if (num_epochs < 0) {
         // Choosing the number of epochs. We use a simple formula to decrease
         // the number of epochs with increasing size, with the aim being that


### PR DESCRIPTION
Hey again, @LTLA. I came across a linker issue while building umappp with a shared lib.

Suppose we have a shared library with some source files that define the implementation of the public interface

```
add_library(mylib SHARED source2.cpp source1.cpp)
```

and both of `source1.cpp` and `source2.cpp` contains `#include umappp/umappp.hpp`. 

If we try to link `mylib` against `umappp` with

```
target_link_libraries(mylib PRIVATE umappp)
```

we receive something like the following error:

```
[build] /usr/bin/ld: CMakeFiles/mylib.dir/src/source2.cpp.o: in function `umappp::choose_num_epochs(int, unsigned long)':
[build] source2.cpp:(.text+0x8c0): multiple definition of `umappp::choose_num_epochs(int, unsigned long)'; CMakeFiles/mylib.dir/src/source1.cpp.source1.cpp:(.text+0x1c0): first defined here
```

The solution is to inline `umappp::choose_num_epochs` - my understanding is that adding `inline` causes the function definition to be shared across the built object files, avoiding multiple definition.  Maybe you will have some insight as to whether there's a better way to handle this.

I see in the docs you specify `INTERFACE` scope when linking, but I think I want `PRIVATE` if consumers of `mylib` don't need to access `umappp`.
