### PR TITLE
Add CMake install targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,62 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.14...3.25)
 
 project(umappp
     VERSION 1.0.0
     DESCRIPTION "A C++ implementation of the UMAP algorithm"
     LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
+# Library
 add_library(umappp INTERFACE)
+add_library(ltla::umappp ALIAS umappp)
 
-target_include_directories(umappp INTERFACE include/)
+target_include_directories(umappp INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ltla>)
+target_compile_features(umappp INTERFACE cxx_std_17)
 
-add_subdirectory(extern)
+# Dependencies
+option(UMAPPP_FETCH_EXTERN "Automatically fetch umappp's external dependencies." ON)
+if(UMAPPP_FETCH_EXTERN)
+    add_subdirectory(extern)
+else()
+    find_package(ltla_aarand CONFIG REQUIRED)
+    find_package(ltla_irlba CONFIG REQUIRED)
+    find_package(ltla_knncolle CONFIG REQUIRED)
+endif()
 
-target_link_libraries(umappp INTERFACE knncolle aarand irlba)
+target_link_libraries(umappp INTERFACE ltla::aarand ltla::irlba ltla::knncolle)
 
+# Tests
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    option(UMAPPP_TESTS "Build umappp's test suite." ON)
+else()
+    option(UMAPPP_TESTS "Build umappp's test suite." OFF)
+endif()
+if(UMAPPP_TESTS)
     include(CTest)
     if(BUILD_TESTING)
         add_subdirectory(tests)
     endif()
 endif()
+
+# Install
+install(DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ltla)
+
+install(TARGETS umappp
+    EXPORT umapppTargets)
+
+install(EXPORT umapppTargets
+    FILE ltla_umapppTargets.cmake
+    NAMESPACE ltla::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ltla_umappp)
+
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/ltla_umapppConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ltla_umappp)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/ltla_umapppConfig.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ltla_umappp)

--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ See the [reference documentation](https://ltla.github.io/umappp) for more detail
 
 ## Building projects
 
+### CMake with `FetchContent`
+
 If you're already using CMake, you can add something like this to your `CMakeLists.txt`:
 
-```
+```cmake
 include(FetchContent)
 
 FetchContent_Declare(
@@ -75,16 +77,37 @@ FetchContent_MakeAvailable(umappp)
 
 And then:
 
-```
+```cmake
 # For executables:
-target_link_libraries(myexe umappp)
+target_link_libraries(myexe ltla::umappp)
 
 # For libaries
-target_link_libraries(mylib INTERFACE umappp)
+target_link_libraries(mylib INTERFACE ltla::umappp)
 ```
 
-Otherwise, you can just copy the directory in `include` into some location that is visible to your compiler.
-Note that this requires the additional dependencies listed in `extern`:
+### CMake with `find_package()`
+
+```cmake
+find_package(ltla_umappp CONFIG REQUIRED)
+target_link_libraries(mylib INTERFACE ltla::umappp)
+```
+
+To install the library, use:
+
+```sh
+mkdir build && cd build
+cmake .. -DUMAPPP_TESTS=OFF
+cmake --build . --target install
+```
+
+By default, this will use `FetchContent` to fetch all external dependencies.
+If you want to install them manually, use `-DUMAPPP_FETCH_EXTERN=OFF`.
+See the commit hashes in [`extern/CMakeLists.txt`](extern/CMakeLists.txt) to find compatible versions of each dependency.
+
+### Manual
+
+If you're not using CMake, the simple approach is to just copy the files in `include/` - either directly or with Git submodules - and include their path during compilation with, e.g., GCC's `-I`.
+This requires the external dependencies listed in [`extern/CMakeLists.txt`](extern/CMakeLists.txt), which also need to be made available during compilation:
 
 - The [**irlba**](https://github.com/LTLA/CppIrlba) library for singular value decomposition (or in this case, an eigendecomposition).
   This also requires the [**Eigen**](https://gitlab.com/libeigen/eigen) library for matrix operations.

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(ltla_aarand CONFIG REQUIRED)
+find_dependency(ltla_irlba CONFIG REQUIRED)
+find_dependency(ltla_knncolle CONFIG REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/ltla_umapppTargets.cmake")

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -3,15 +3,15 @@ include(FetchContent)
 FetchContent_Declare(
   aarand
   GIT_REPOSITORY https://github.com/LTLA/aarand
-  GIT_TAG bd06e0d52e59e35f0456a870746a959da4bc7cb3
+  GIT_TAG 84d48b65d49ce8b844398f11aff3015b86e17197
 )
 
 FetchContent_MakeAvailable(aarand)
 
 FetchContent_Declare(
-  knncolle 
-  GIT_REPOSITORY https://github.com/LTLA/knncolle
-  GIT_TAG 560436d142d08eb505fe63fb7eac12ed46fda345
+  knncolle
+  GIT_REPOSITORY https://github.com/moritz-h/knncolle
+  GIT_TAG cmake
 )
 
 FetchContent_MakeAvailable(knncolle)
@@ -19,7 +19,7 @@ FetchContent_MakeAvailable(knncolle)
 FetchContent_Declare(
   irlba 
   GIT_REPOSITORY https://github.com/LTLA/CppIrlba
-  GIT_TAG 64d7da3e7050ce228b10c8f3057d6d7bcb740593
+  GIT_TAG 0eee555f27aedefad4bd164d7fc93610aed54e13
 )
 
 FetchContent_MakeAvailable(irlba)

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -10,8 +10,8 @@ FetchContent_MakeAvailable(aarand)
 
 FetchContent_Declare(
   knncolle
-  GIT_REPOSITORY https://github.com/moritz-h/knncolle
-  GIT_TAG cmake
+  GIT_REPOSITORY https://github.com/LTLA/knncolle
+  GIT_TAG 3ad6b8cdbd281d78c77390d5a6ded4513bdf3860
 )
 
 FetchContent_MakeAvailable(knncolle)
@@ -19,7 +19,7 @@ FetchContent_MakeAvailable(knncolle)
 FetchContent_Declare(
   irlba 
   GIT_REPOSITORY https://github.com/LTLA/CppIrlba
-  GIT_TAG 0eee555f27aedefad4bd164d7fc93610aed54e13
+  GIT_TAG d23a4c12b95563907cf8ca7584b7bb6625ff886b
 )
 
 FetchContent_MakeAvailable(irlba)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,10 @@ FetchContent_Declare(
 
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+# Avoid installing GoogleTest when installing this project.
+option(INSTALL_GTEST "Enable installation of googletest." OFF)
+
 FetchContent_MakeAvailable(googletest)
 
 enable_testing()


### PR DESCRIPTION
After all dependencies, the final PR for bringing CMake install targets to umappp.

Depends on https://github.com/LTLA/knncolle/pull/6.
It is required to update the knncolle reference in `extern/CMakeLists.txt` once https://github.com/LTLA/knncolle/pull/6 is merged, therefore, open as draft.